### PR TITLE
bugfix: prevent unintended shared metadata updates in function `assign_and_map_hash_ids`

### DIFF
--- a/unstructured/documents/elements.py
+++ b/unstructured/documents/elements.py
@@ -552,7 +552,11 @@ def assign_and_map_hash_ids(elements: list[Element]) -> list[Element]:
         parent_id = e.metadata.parent_id
         if not parent_id:
             continue
-        e.metadata.parent_id = old_to_new_mapping[parent_id]
+        metadata = copy.deepcopy(e.metadata)
+        if not old_to_new_mapping.get(parent_id):
+            raise KeyError(f"Parent ID {parent_id} not found in mapping.")
+        metadata.parent_id = old_to_new_mapping[parent_id]
+        e.metadata = metadata
 
     return elements
 


### PR DESCRIPTION
## short description

This short PR addresses a bug in the `assign_and_map_hash_ids` function where multiple `Element` instances could share the same `ElementMetadata` instance.

This could inadvertently introduce unintended side effects when updating the `parent_id`.

## original behavior
Here it will raise the `KeyError` since the underlying metadata object could have been updated earlier pointed by the other element associated with the same metadata object.